### PR TITLE
[FEAT] Rules탭 카테고리 CVC 기능구현 포함한 뷰 연결 및 TodayTodo 담당자 설정

### DIFF
--- a/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
+++ b/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
@@ -165,15 +165,12 @@
 		B59C947A2877098D005865CA /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		B5A7D19928809B180037F210 /* QuitTestPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitTestPopUpViewController.swift; sourceTree = "<group>"; };
 		B5BD75D028801F4C00B98D35 /* IconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconFactory.swift; sourceTree = "<group>"; };
-<<<<<<< HEAD
 		B5F8583728802B4A009474A1 /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
 		B5F858392880531A009474A1 /* ProfileTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestViewController.swift; sourceTree = "<group>"; };
 		B5F8583C28805EEF009474A1 /* TestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCollectionViewCell.swift; sourceTree = "<group>"; };
 		B5F8583E288069B6009474A1 /* ProfileTestDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestDataModel.swift; sourceTree = "<group>"; };
 		B5F8584028806E95009474A1 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
-=======
 		B80418C328808E450060A9C9 /* CategoryIconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryIconFactory.swift; sourceTree = "<group>"; };
->>>>>>> [#31] FEAT : Category Collection View Cell 분기처리 및 didSelect 액션
 		B805109E2876D2D10025B767 /* Hous-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hous-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80510A12876D2D10025B767 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B80510A32876D2D10025B767 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };

--- a/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
+++ b/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		B5F8583D28805EEF009474A1 /* TestCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8583C28805EEF009474A1 /* TestCollectionViewCell.swift */; };
 		B5F8583F288069B6009474A1 /* ProfileTestDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8583E288069B6009474A1 /* ProfileTestDataModel.swift */; };
 		B5F8584128806E95009474A1 /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F8584028806E95009474A1 /* UIImageView+Extension.swift */; };
+		B80418C428808E450060A9C9 /* CategoryIconFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80418C328808E450060A9C9 /* CategoryIconFactory.swift */; };
 		B80510A22876D2D10025B767 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80510A12876D2D10025B767 /* AppDelegate.swift */; };
 		B80510A42876D2D10025B767 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80510A32876D2D10025B767 /* SceneDelegate.swift */; };
 		B80510AB2876D2D20025B767 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B80510AA2876D2D20025B767 /* Assets.xcassets */; };
@@ -164,11 +165,15 @@
 		B59C947A2877098D005865CA /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		B5A7D19928809B180037F210 /* QuitTestPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitTestPopUpViewController.swift; sourceTree = "<group>"; };
 		B5BD75D028801F4C00B98D35 /* IconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconFactory.swift; sourceTree = "<group>"; };
+<<<<<<< HEAD
 		B5F8583728802B4A009474A1 /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
 		B5F858392880531A009474A1 /* ProfileTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestViewController.swift; sourceTree = "<group>"; };
 		B5F8583C28805EEF009474A1 /* TestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCollectionViewCell.swift; sourceTree = "<group>"; };
 		B5F8583E288069B6009474A1 /* ProfileTestDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestDataModel.swift; sourceTree = "<group>"; };
 		B5F8584028806E95009474A1 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
+=======
+		B80418C328808E450060A9C9 /* CategoryIconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryIconFactory.swift; sourceTree = "<group>"; };
+>>>>>>> [#31] FEAT : Category Collection View Cell 분기처리 및 didSelect 액션
 		B805109E2876D2D10025B767 /* Hous-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hous-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80510A12876D2D10025B767 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B80510A32876D2D10025B767 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -631,6 +636,7 @@
 			children = (
 				B87BD3E3287F1FCF00FE232D /* AssigneeFactory.swift */,
 				B5BD75D028801F4C00B98D35 /* IconFactory.swift */,
+				B80418C328808E450060A9C9 /* CategoryIconFactory.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -788,6 +794,7 @@
 				9B648B8E28805D28005E9322 /* ProfileViewController.swift in Sources */,
 				B5A7D19A28809B180037F210 /* QuitTestPopUpViewController.swift in Sources */,
 				B843442E287C90E800CD1BF5 /* CategoryRulesAssigneeView.swift in Sources */,
+				B80418C428808E450060A9C9 /* CategoryIconFactory.swift in Sources */,
 				B80510A22876D2D10025B767 /* AppDelegate.swift in Sources */,
 				778A7A0B28770EB700722CBB /* HousTabbar.swift in Sources */,
 				B80510E62876D6F10025B767 /* NetworkResult.swift in Sources */,

--- a/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
+++ b/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		B87BD3E4287F1FCF00FE232D /* AssigneeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87BD3E3287F1FCF00FE232D /* AssigneeFactory.swift */; };
 		B87BD3EA287FE48300FE232D /* TodoTabEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87BD3E9287FE48300FE232D /* TodoTabEnum.swift */; };
 		B87BD3EC2880024F00FE232D /* UIBezierPath+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87BD3EB2880024F00FE232D /* UIBezierPath+Extension.swift */; };
+		B87BD3EF2880273900FE232D /* RulesAssignPopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87BD3EE2880273900FE232D /* RulesAssignPopUpViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -205,6 +206,7 @@
 		B87BD3E3287F1FCF00FE232D /* AssigneeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeFactory.swift; sourceTree = "<group>"; };
 		B87BD3E9287FE48300FE232D /* TodoTabEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoTabEnum.swift; sourceTree = "<group>"; };
 		B87BD3EB2880024F00FE232D /* UIBezierPath+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBezierPath+Extension.swift"; sourceTree = "<group>"; };
+		B87BD3EE2880273900FE232D /* RulesAssignPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesAssignPopUpViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -491,6 +493,7 @@
 		B80510BC2876D32D0025B767 /* Rules */ = {
 			isa = PBXGroup;
 			children = (
+				B87BD3ED2880272400FE232D /* PopUp */,
 				B87BD3E8287FE46300FE232D /* Enum */,
 				B8434433287CEB6200CD1BF5 /* ViewModel */,
 				B84387102879571C003F7B75 /* Cell */,
@@ -638,6 +641,14 @@
 				B87BD3E9287FE48300FE232D /* TodoTabEnum.swift */,
 			);
 			path = Enum;
+			sourceTree = "<group>";
+		};
+		B87BD3ED2880272400FE232D /* PopUp */ = {
+			isa = PBXGroup;
+			children = (
+				B87BD3EE2880273900FE232D /* RulesAssignPopUpViewController.swift */,
+			);
+			path = PopUp;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -814,6 +825,7 @@
 				B80510C72876D38A0025B767 /* UIFont+Extension.swift in Sources */,
 				9B81422B287D3FE30073E533 /* ProfileGraphView.swift in Sources */,
 				B80510C32876D36A0025B767 /* HomeViewController.swift in Sources */,
+				B87BD3EF2880273900FE232D /* RulesAssignPopUpViewController.swift in Sources */,
 				778A79FC287704E500722CBB /* Strings.swift in Sources */,
 				778A79FA287704D400722CBB /* SplashViewController.swift in Sources */,
 				B843871E28795E0C003F7B75 /* NavigationBarView.swift in Sources */,

--- a/Hous-iOS/Hous-iOS/Global/Protocol/CategoryIconFactory.swift
+++ b/Hous-iOS/Hous-iOS/Global/Protocol/CategoryIconFactory.swift
@@ -1,0 +1,80 @@
+//
+//  CategoryIconFactory.swift
+//  Hous-iOS
+//
+//  Created by 김지현 on 2022/07/15.
+//
+
+import UIKit
+
+enum CategoryIconImage: String {
+  case light, cake, beer, coffee, clean, trash, heart, laundry
+}
+
+protocol CategoryIconProtocol {
+  var unCheckedImage: UIImage { get set }
+  //var checkedImage: UIImage { get set }
+}
+
+struct CategoryLightIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.light
+  //var checkedImage = R.Image.partyYellowSmall
+}
+
+struct CategoryCakeIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.cake
+  //var checkedImage = R.Image.cakeYellowSmall
+}
+
+struct CategoryBeerIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.beer
+  //var checkedImage = R.Image.beerYellowSmall
+}
+
+struct CategoryCoffeeIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.coffee
+  //var checkedImage = R.Image.coffeeYellowSmall
+}
+
+struct CategoryCleanIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.clean
+  //var checkedImage = R.Image.coffeeYellowSmall
+}
+
+struct CategoryTrashIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.trash
+  //var checkedImage = R.Image.coffeeYellowSmall
+}
+
+struct CategoryHeartIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.heart
+  //var checkedImage = R.Image.coffeeYellowSmall
+}
+
+struct CategoryLaundryIcon: CategoryIconProtocol {
+  var unCheckedImage = R.Image.laundry
+  //var checkedImage = R.Image.coffeeYellowSmall
+}
+
+struct CategoryIconFactory {
+  static func makeIcon(type: CategoryIconImage) -> CategoryIconProtocol {
+    switch type {
+    case .light:
+      return CategoryLightIcon()
+    case .cake:
+      return CategoryCakeIcon()
+    case .beer:
+      return CategoryBeerIcon()
+    case .coffee:
+      return CategoryCoffeeIcon()
+    case .clean:
+      return CategoryCleanIcon()
+    case .trash:
+      return CategoryTrashIcon()
+    case .heart:
+      return CategoryHeartIcon()
+    case .laundry:
+      return CategoryLaundryIcon()
+    }
+  }
+}

--- a/Hous-iOS/Hous-iOS/Network/Model/CategoryRulesDataModel.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/CategoryRulesDataModel.swift
@@ -7,6 +7,30 @@
 
 import Foundation
 
+typealias Categories = [Category]
+struct Category: Codable {
+    let id, categoryName, categoryIcon: String
+
+    enum CodingKeys: String, CodingKey {
+      case id
+      case categoryName = "ruleCategoryName"
+      case categoryIcon = "ruleCategoryIcon"
+    }
+}
+
+extension Category {
+  static let sampleData: Categories = [
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "다섯글자임", categoryIcon: "CLEAN"),
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "파티", categoryIcon: "PARTY"),
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "커피", categoryIcon: "COFFEE"),
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "팬케이크", categoryIcon: "CAKE"),
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "불끄세요", categoryIcon: "LIGHT"),
+    Category(id: "62cc752dd7868591384e4ed4", categoryName: "빨래", categoryIcon: "LAUNDRY")
+  ]
+}
+
+
+// --------------------------------------------------
 struct CategoryRulesDataModel {
   let assigneeColor: [AssigneeColor]
   let assigneeCount: Int

--- a/Hous-iOS/Hous-iOS/Screens/Rules/Cell/CategoryCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/Cell/CategoryCollectionViewCell.swift
@@ -20,6 +20,13 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     $0.font = .font(.spoqaHanSansNeoMedium, ofSize: 13)
     $0.textAlignment = .center
     $0.text = "청소"
+    $0.isHidden = true
+  }
+
+  override var isSelected: Bool {
+    didSet {
+      self.isSelected ? (categoryTitleLabel.isHidden = false) : (categoryTitleLabel.isHidden = true)
+    }
   }
   
   override init(frame: CGRect) {
@@ -44,5 +51,15 @@ class CategoryCollectionViewCell: UICollectionViewCell {
       make.leading.trailing.equalToSuperview()
       make.top.equalTo(categoryImageView.snp.bottom).offset(2)
     }
+  }
+}
+
+extension CategoryCollectionViewCell {
+
+  func setCategory(_ item: Category) {
+    guard let categoryIconType = CategoryIconImage(rawValue: item.categoryIcon.lowercased()) else { return }
+    let categoryIcon = CategoryIconFactory.makeIcon(type: categoryIconType)
+    self.categoryImageView.image = categoryIcon.unCheckedImage
+    self.categoryTitleLabel.text = item.categoryName
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Rules/Cell/Todo/TodayTodoCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/Cell/Todo/TodayTodoCollectionViewCell.swift
@@ -128,7 +128,7 @@ extension TodayTodoCollectionViewCell {
         touch.view == self.oneAssignedView {
       delegate?.leftAssigneeViewTouched()
     } else {
-      print("나머지 부분 터치했지롱")
+      // 나머지 부분 터치 시 기능 구현 예정
     }
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Rules/Cell/Todo/TodayTodoCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/Cell/Todo/TodayTodoCollectionViewCell.swift
@@ -7,7 +7,14 @@
 
 import UIKit
 
+protocol TodayTodoCollectionViewCellDelegate: AnyObject {
+  func leftAssigneeViewTouched()
+  // func cellTouched()
+}
+
 class TodayTodoCollectionViewCell: UICollectionViewCell {
+
+  weak var delegate: TodayTodoCollectionViewCellDelegate?
 
   enum Size {
     static let leftRoundViewSize: CGFloat = 40
@@ -87,19 +94,6 @@ class TodayTodoCollectionViewCell: UICollectionViewCell {
   }
 }
 
-//extension TodayTodoCollectionViewCell {
-//  func setLeftRoundView(type: TodayTodoType) {
-//    switch type {
-//    case .notAssigned:
-//      leftAssigneeView = TodayTodoAddAssingnView()
-//    case .manyAssinged:
-//      leftAssigneeView = manyAssignedView
-//    case .oneAssinged:
-//      leftAssigneeView = oneAssignedView
-//    }
-//  }
-//}
-
 extension TodayTodoCollectionViewCell {
 
     func setLeftRoundView(type: TodayTodoType) {
@@ -121,4 +115,20 @@ extension TodayTodoCollectionViewCell {
         }
       }
     }
+}
+
+extension TodayTodoCollectionViewCell {
+
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+      super.touchesBegan(touches, with: event)
+
+    guard let touch = touches.reversed().first else { return }
+    if touch.view == self.addAssignView ||
+        touch.view == self.manyAssignedView ||
+        touch.view == self.oneAssignedView {
+      delegate?.leftAssigneeViewTouched()
+    } else {
+      print("나머지 부분 터치했지롱")
+    }
+  }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Rules/Controller/RulesViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/Controller/RulesViewController.swift
@@ -12,9 +12,10 @@ import RxSwift
 import RxCocoa
 
 final class RulesViewController: UIViewController {
-  
+
+  var categories: Categories?
+
   let disposeBag = DisposeBag()
-  
   var mainView = RulesHomeView()
 
   override func loadView() {
@@ -26,6 +27,7 @@ final class RulesViewController: UIViewController {
     configUI()
     setCollectionView()
     setAction()
+    getCategories()
     binding()
   }
 
@@ -45,6 +47,10 @@ final class RulesViewController: UIViewController {
       todayTodoAssignPopUp.modalPresentationStyle = .overFullScreen
       self.present(todayTodoAssignPopUp, animated: true)
     }
+  }
+
+  private func getCategories() {
+    categories = Category.sampleData
   }
 }
 
@@ -78,12 +84,31 @@ extension RulesViewController {
 extension RulesViewController: UICollectionViewDelegate, UICollectionViewDataSource {
 
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 8
+    return Category.sampleData.count + 1
   }
 
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.className, for: indexPath)
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.className, for: indexPath) as? CategoryCollectionViewCell else { return UICollectionViewCell() }
+
+    if indexPath.row == categories?.count {
+      cell.categoryImageView.image = R.Image.categoryAdd
+      cell.isSelected = false
+    } else {
+      cell.setCategory(categories![indexPath.row])
+    }
+
     return cell
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+
+    let cell = collectionView.cellForItem(at: indexPath) as! CategoryCollectionViewCell
+
+    cell.isSelected = true
+
+    indexPath.row != categories?.count ? (self.mainView.rulesType = .category) : (self.mainView.rulesType = .editCategory)
+
+    self.mainView.todayTodoButton.isSelected = false
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Rules/Controller/RulesViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/Controller/RulesViewController.swift
@@ -25,6 +25,7 @@ final class RulesViewController: UIViewController {
     super.viewDidLoad()
     configUI()
     setCollectionView()
+    setAction()
     binding()
   }
 
@@ -35,6 +36,15 @@ final class RulesViewController: UIViewController {
   private func setCollectionView() {
     mainView.categoryCollectionView.delegate = self
     mainView.categoryCollectionView.dataSource = self
+  }
+
+  private func setAction() {
+    mainView.todoTableView.leftAssigneeViewAction = {
+      let todayTodoAssignPopUp = TodayTodoAssignPopUpViewController()
+      todayTodoAssignPopUp.modalTransitionStyle = .crossDissolve
+      todayTodoAssignPopUp.modalPresentationStyle = .overFullScreen
+      self.present(todayTodoAssignPopUp, animated: true)
+    }
   }
 }
 

--- a/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
@@ -1,0 +1,158 @@
+//
+//  TodayTodoAssignPopUpViewController.swift
+//  Hous-iOS
+//
+//  Created by 김지현 on 2022/07/14.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class TodayTodoAssignPopUpViewController: UIViewController {
+
+  private enum Size {
+    static let screenWidth = UIScreen.main.bounds.width
+    static let assigneeSize = CGSize(width: 56, height: 82)
+  }
+
+  private lazy var blurView = UIVisualEffectView().then {
+    let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
+    $0.effect = blurEffect
+    $0.frame = view.bounds
+    $0.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+  }
+
+  private let popUpView = UIView().then {
+    $0.backgroundColor = .white
+    $0.layer.cornerRadius = 20
+  }
+
+  private let titleLabel = UILabel().then {
+    $0.text = "임시 담당자 설정"
+    $0.font = .font(.spoqaHanSansNeoBold, ofSize: 20)
+    $0.tintColor = .housBlack
+  }
+
+  private lazy var popUpCloseButton = UIButton().then {
+    $0.setImage(R.Image.popupCloseHome, for: .normal)
+    $0.addTarget(self, action: #selector(cancelButtonDidTapped), for: .touchUpInside)
+  }
+
+  private let assigneeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout()).then {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .horizontal
+    $0.collectionViewLayout = layout
+    $0.showsHorizontalScrollIndicator = false
+  }
+
+  private let saveButton = UIButton().then {
+    var config = UIButton.Configuration.plain()
+    var container = AttributeContainer()
+    container.font = .font(.spoqaHanSansNeoMedium, ofSize: 16)
+
+    config.attributedTitle = AttributedString("저장", attributes: container)
+    $0.configuration = config
+    $0.backgroundColor = .softBlue
+    $0.tintColor = .white
+    $0.layer.cornerRadius = 10
+  }
+
+  //MARK: Life Cycle
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    render()
+    setCollectionView()
+  }
+
+  private func render() {
+
+    self.view.addSubView(blurView)
+    self.view.addSubview(popUpView)
+    popUpView.addSubViews([titleLabel, popUpCloseButton, assigneeCollectionView, saveButton])
+
+    popUpView.snp.makeConstraints { make in
+      make.center.equalToSuperview()
+      make.width.equalTo(UIScreen.main.bounds.width * (272/375))
+      make.height.equalTo(popUpView.snp.width).multipliedBy(0.9)
+    }
+
+    titleLabel.snp.makeConstraints { make in
+      make.top.leading.equalToSuperview().offset(24)
+    }
+
+    popUpCloseButton.snp.makeConstraints { make in
+      make.centerY.equalTo(titleLabel.snp.centerY)
+      make.trailing.equalTo(popUpView).inset(24)
+      make.size.equalTo(24)
+    }
+
+    assigneeCollectionView.snp.makeConstraints { make in
+      make.top.equalTo(titleLabel.snp.bottom).offset(20)
+      make.leading.trailing.equalToSuperview()
+    } // 얘 height 지정 안되어 있음 !
+
+    saveButton.snp.makeConstraints { make in
+      make.top.equalTo(assigneeCollectionView.snp.bottom).offset(24)
+      make.leading.trailing.bottom.equalToSuperview().inset(24)
+      make.height.equalTo(40)
+    }
+  }
+
+  private func setCollectionView() {
+    assigneeCollectionView.register(cell: ParticipantsCollectionViewCell.self)
+    assigneeCollectionView.delegate = self
+    assigneeCollectionView.dataSource = self
+  }
+}
+
+//MARK: Objective-C methods
+extension TodayTodoAssignPopUpViewController {
+  @objc private func cancelButtonDidTapped() {
+    print("캔슬버튼")
+    self.dismiss(animated: true)
+  }
+}
+
+//MARK: Delegate & Datasource
+extension TodayTodoAssignPopUpViewController: UICollectionViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let cell = collectionView.cellForItem(at: indexPath) as? ParticipantsCollectionViewCell else { return }
+
+    cell.participantButton.isSelected.toggle()
+  }
+}
+
+extension TodayTodoAssignPopUpViewController: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return ParticipantsDataModel.sampleData.count
+  }
+
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    if collectionView == assigneeCollectionView {
+      guard let cell = assigneeCollectionView.dequeueReusableCell(withReuseIdentifier: ParticipantsCollectionViewCell.className, for: indexPath) as? ParticipantsCollectionViewCell else { return UICollectionViewCell() }
+
+      cell.contentView.isUserInteractionEnabled = true
+      cell.setParticipantData(ParticipantsDataModel.sampleData[indexPath.row])
+
+      return cell
+    }
+
+    return UICollectionViewCell()
+  }
+}
+
+extension TodayTodoAssignPopUpViewController: UICollectionViewDelegateFlowLayout {
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+
+    return Size.assigneeSize
+  }
+
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 0)
+  }
+
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 16
+  }
+}

--- a/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
@@ -109,7 +109,6 @@ class TodayTodoAssignPopUpViewController: UIViewController {
 //MARK: Objective-C methods
 extension TodayTodoAssignPopUpViewController {
   @objc private func cancelButtonDidTapped() {
-    print("캔슬버튼")
     self.dismiss(animated: true)
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesCategoryView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesCategoryView.swift
@@ -1,5 +1,5 @@
 //
-//  RulesCategoryView.swift
+//  RulesCategoryEditView.swift
 //  Hous-iOS
 //
 //  Created by 김지현 on 2022/07/12.
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class RulesCategoryView: UIView {
+final class RulesCategoryEditView: UIView {
 
   //MARK: - 변수
 

--- a/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesHomeView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesHomeView.swift
@@ -11,9 +11,8 @@ class RulesHomeView: UIView {
   
   enum Size {
     static let horizontalButtonViewHeight = 110
-    static let categoryCollectionItemSize = CGSize(width: 43, height: horizontalButtonViewHeight)
+    static let categoryCollectionItemSize = CGSize(width: 60, height: horizontalButtonViewHeight)
     static let categoryCollectionEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 20)
-    static let categoryCollectionItemSpacing = CGFloat(24)
   }
 
   var rulesType: RulesType = .todo {
@@ -36,7 +35,6 @@ class RulesHomeView: UIView {
       let layout = UICollectionViewFlowLayout()
       layout.itemSize = Size.categoryCollectionItemSize
       layout.sectionInset = Size.categoryCollectionEdgeInsets
-      layout.minimumLineSpacing = Size.categoryCollectionItemSpacing
       layout.scrollDirection = .horizontal
       $0.collectionViewLayout = layout
       $0.showsHorizontalScrollIndicator = false
@@ -46,7 +44,7 @@ class RulesHomeView: UIView {
 
   lazy var categoryTableView = RulesCategoryTableView()
   lazy var todoTableView = RulesTodoTableView()
-  lazy var categoryView = RulesCategoryView(editType: .add)
+  lazy var categoryView = RulesCategoryEditView(editType: .add)
   var rulesDisplayView = UIView()
   
   override init(frame: CGRect) {
@@ -81,7 +79,7 @@ class RulesHomeView: UIView {
       make.size.equalTo(40)
     }
     categoryCollectionView.snp.makeConstraints { make in
-      make.leading.equalTo(todayTodoButton.snp.trailing).offset(24)
+      make.leading.equalTo(todayTodoButton.snp.trailing).offset(22)
       make.top.bottom.trailing.equalToSuperview()
     }
     

--- a/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesTodoTableView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesTodoTableView.swift
@@ -12,8 +12,6 @@ import Then
 final class RulesTodoTableView: UIView {
 
   var leftAssigneeViewAction : (() -> Void)?
-
-  // 데이터모델 정의
   
   enum Size {
     static let screenWidth = UIScreen.main.bounds.width

--- a/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesTodoTableView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/View/RulesTodoTableView.swift
@@ -9,9 +9,9 @@ import UIKit
 import SnapKit
 import Then
 
-
-
 final class RulesTodoTableView: UIView {
+
+  var leftAssigneeViewAction : (() -> Void)?
 
   // 데이터모델 정의
   
@@ -19,7 +19,7 @@ final class RulesTodoTableView: UIView {
     static let screenWidth = UIScreen.main.bounds.width
     static let itemWidth = screenWidth * 0.9
     static let todoCollectionItemSize = CGSize(width: itemWidth, height: 80)
-    static let todoCollectionEdgeInsets = UIEdgeInsets(top: 0, left: 20, bottom: 120, right: 20)
+    static let todoCollectionEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 120, right: 0)
     static let todoCollectionItemSpacing = CGFloat(8)
   }
   
@@ -56,7 +56,7 @@ final class RulesTodoTableView: UIView {
       $0.register(cell: TodayTodoCollectionViewCell.self)
       $0.register(cell: MyTodoCollectionViewCell.self)
     }
-  
+
   var items: [String] = []
   
   override init(frame: CGRect) {
@@ -100,6 +100,8 @@ extension RulesTodoTableView: UICollectionViewDataSource, UICollectionViewDelega
     switch todoType {
     case .todayTodo:
       guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TodayTodoCollectionViewCell.className, for: indexPath) as? TodayTodoCollectionViewCell else { return UICollectionViewCell() }
+
+      cell.delegate = self
       cell.setLeftRoundView(type: .notAssigned)
       // many랑 one didSet 처리해주기
       return cell
@@ -107,5 +109,11 @@ extension RulesTodoTableView: UICollectionViewDataSource, UICollectionViewDelega
       let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyTodoCollectionViewCell.className, for: indexPath)
       return cell
     }
+  }
+}
+
+extension RulesTodoTableView: TodayTodoCollectionViewCellDelegate {
+  func leftAssigneeViewTouched() {
+    leftAssigneeViewAction?()
   }
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- 규칙탭 뷰 연결
- 담당자 설정 및 수정 팝업
- 카테고리 CollectionView 기능 구현

## 🌱 PR Point

- delegate 와 클로저의 혼연일체 ... 코드가 점점 .... 복잡해져요 ... 클린코드 ... 어케하는거임 .. 점점 뭔가 한 파일 내에서 보기 좋게끔 정렬하는게 힘들어지는 것 같음

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ex. 규칙탭 뷰연결과 담당자팝업 | ![Simulator Screen Recording - iPhone 11 Pro - 2022-07-15 at 19 57 47](https://user-images.githubusercontent.com/59338503/179210355-6dbb7021-5be4-4505-b76a-f70e8071d5c1.gif) |

## 📮 관련 이슈

- Resolved: #31 
