### PR TITLE
[#40] FEAT : 이벤트 팝업창 API명세서에 맞게 수정

### DIFF
--- a/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
+++ b/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B5BD75D128801F4C00B98D35 /* IconFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BD75D028801F4C00B98D35 /* IconFactory.swift */; };
 		B5C2D3AB2880263800843196 /* HousTabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A8FC27287936A500F5376B /* HousTabbarViewController.swift */; };
 		B5E95ADC2881917B00CD2244 /* HomeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95ADB2881917B00CD2244 /* HomeDTO.swift */; };
+		B5E95ADE2881B63000CD2244 /* EventDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95ADD2881B63000CD2244 /* EventDTO.swift */; };
 		B5ED92522880245D00E3C10F /* CategoryRulesDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8434431287CA7AC00CD1BF5 /* CategoryRulesDataModel.swift */; };
 		B5F8583428802782009474A1 /* RulesCategoryTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84344232879A36600CD1BF5 /* RulesCategoryTableView.swift */; };
 		B5F858352880278D009474A1 /* EventDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5084A44287D6C1000C38749 /* EventDateView.swift */; };
@@ -160,6 +161,7 @@
 		B5A7D19928809B180037F210 /* QuitTestPopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitTestPopUpViewController.swift; sourceTree = "<group>"; };
 		B5BD75D028801F4C00B98D35 /* IconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconFactory.swift; sourceTree = "<group>"; };
 		B5E95ADB2881917B00CD2244 /* HomeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDTO.swift; sourceTree = "<group>"; };
+		B5E95ADD2881B63000CD2244 /* EventDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDTO.swift; sourceTree = "<group>"; };
 		B5F8583728802B4A009474A1 /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
 		B5F858392880531A009474A1 /* ProfileTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestViewController.swift; sourceTree = "<group>"; };
 		B5F8583C28805EEF009474A1 /* TestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 			isa = PBXGroup;
 			children = (
 				B5E95ADB2881917B00CD2244 /* HomeDTO.swift */,
+				B5E95ADD2881B63000CD2244 /* EventDTO.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -846,6 +849,7 @@
 				B59C94752877094F005865CA /* NSObject+Extension.swift in Sources */,
 				9B1F1C10287E6DA100A15D82 /* ProfileGraphEmptyCollectionViewCell.swift in Sources */,
 				B8434437287D920900CD1BF5 /* RulesCategoryView.swift in Sources */,
+				B5E95ADE2881B63000CD2244 /* EventDTO.swift in Sources */,
 				9B7D860F287C487C006C0BCE /* ProfileGraphCollectionViewCell.swift in Sources */,
 				B5084A43287CAC1300C38749 /* EventIconView.swift in Sources */,
 				B843871A28795881003F7B75 /* TodayTodoCollectionViewCell.swift in Sources */,

--- a/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
+++ b/Hous-iOS/Hous-iOS.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		B5C2D3AB2880263800843196 /* HousTabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A8FC27287936A500F5376B /* HousTabbarViewController.swift */; };
 		B5E95ADC2881917B00CD2244 /* HomeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95ADB2881917B00CD2244 /* HomeDTO.swift */; };
 		B5E95ADE2881B63000CD2244 /* EventDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95ADD2881B63000CD2244 /* EventDTO.swift */; };
+		B5E95AE02881DB1100CD2244 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95ADF2881DB1100CD2244 /* String+Extension.swift */; };
+		B5E95AE22881DB2A00CD2244 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E95AE12881DB2A00CD2244 /* Date+Extension.swift */; };
 		B5ED92522880245D00E3C10F /* CategoryRulesDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8434431287CA7AC00CD1BF5 /* CategoryRulesDataModel.swift */; };
 		B5F8583428802782009474A1 /* RulesCategoryTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84344232879A36600CD1BF5 /* RulesCategoryTableView.swift */; };
 		B5F858352880278D009474A1 /* EventDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5084A44287D6C1000C38749 /* EventDateView.swift */; };
@@ -162,6 +164,8 @@
 		B5BD75D028801F4C00B98D35 /* IconFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconFactory.swift; sourceTree = "<group>"; };
 		B5E95ADB2881917B00CD2244 /* HomeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDTO.swift; sourceTree = "<group>"; };
 		B5E95ADD2881B63000CD2244 /* EventDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDTO.swift; sourceTree = "<group>"; };
+		B5E95ADF2881DB1100CD2244 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		B5E95AE12881DB2A00CD2244 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		B5F8583728802B4A009474A1 /* ProfileTestInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestInfoViewController.swift; sourceTree = "<group>"; };
 		B5F858392880531A009474A1 /* ProfileTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTestViewController.swift; sourceTree = "<group>"; };
 		B5F8583C28805EEF009474A1 /* TestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -508,6 +512,8 @@
 				B5084A3528799AEB00C38749 /* UIColor+Extension.swift */,
 				B87BD3EB2880024F00FE232D /* UIBezierPath+Extension.swift */,
 				B5F8584028806E95009474A1 /* UIImageView+Extension.swift */,
+				B5E95ADF2881DB1100CD2244 /* String+Extension.swift */,
+				B5E95AE12881DB2A00CD2244 /* Date+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -820,6 +826,7 @@
 				B59C947728770961005865CA /* UITableView+Extension.swift in Sources */,
 				9B648B8E28805D28005E9322 /* ProfileViewController.swift in Sources */,
 				B5A7D19A28809B180037F210 /* QuitTestPopUpViewController.swift in Sources */,
+				B5E95AE02881DB1100CD2244 /* String+Extension.swift in Sources */,
 				B843442E287C90E800CD1BF5 /* CategoryRulesAssigneeView.swift in Sources */,
 				B80418C428808E450060A9C9 /* CategoryIconFactory.swift in Sources */,
 				B80510A22876D2D10025B767 /* AppDelegate.swift in Sources */,
@@ -851,6 +858,7 @@
 				B8434437287D920900CD1BF5 /* RulesCategoryView.swift in Sources */,
 				B5E95ADE2881B63000CD2244 /* EventDTO.swift in Sources */,
 				9B7D860F287C487C006C0BCE /* ProfileGraphCollectionViewCell.swift in Sources */,
+				B5E95AE22881DB2A00CD2244 /* Date+Extension.swift in Sources */,
 				B5084A43287CAC1300C38749 /* EventIconView.swift in Sources */,
 				B843871A28795881003F7B75 /* TodayTodoCollectionViewCell.swift in Sources */,
 				B5BD75D128801F4C00B98D35 /* IconFactory.swift in Sources */,

--- a/Hous-iOS/Hous-iOS/Global/Extension/Date+Extension.swift
+++ b/Hous-iOS/Hous-iOS/Global/Extension/Date+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  Date+Extension.swift
+//  Hous-iOS
+//
+//  Created by 김민재 on 2022/07/16.
+//
+
+import Foundation

--- a/Hous-iOS/Hous-iOS/Global/Extension/Date+Extension.swift
+++ b/Hous-iOS/Hous-iOS/Global/Extension/Date+Extension.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+
+extension Date {
+  var year: Int {
+    let calendar = Calendar.current
+    return calendar.component(.year, from: self)
+  }
+  
+  var month: Int {
+    let calendar = Calendar.current
+    return calendar.component(.month, from: self)
+  }
+  
+  var day: Int {
+    let calendar = Calendar.current
+    return calendar.component(.day, from: self)
+  }
+}

--- a/Hous-iOS/Hous-iOS/Global/Extension/String+Extension.swift
+++ b/Hous-iOS/Hous-iOS/Global/Extension/String+Extension.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+extension String {
+  func toDate() -> Date? {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.timeZone = TimeZone(identifier: "UTC")
+    
+    if let date = dateFormatter.date(from: self) {
+      return date
+    } else {
+      return nil
+    }
+  }
+}

--- a/Hous-iOS/Hous-iOS/Global/Extension/String+Extension.swift
+++ b/Hous-iOS/Hous-iOS/Global/Extension/String+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  String+Extension.swift
+//  Hous-iOS
+//
+//  Created by 김민재 on 2022/07/16.
+//
+
+import Foundation

--- a/Hous-iOS/Hous-iOS/Global/Protocol/AssigneeFactory.swift
+++ b/Hous-iOS/Hous-iOS/Global/Protocol/AssigneeFactory.swift
@@ -48,7 +48,7 @@ struct GreenAssignee: AssigneeProtocol {
 }
 
 struct NoAssignee: AssigneeProtocol {
-  var checkedFaceImage = R.Image.faceEmpty
+  var checkedFaceImage = R.Image.faceCheckedBlue
   var faceImage = R.Image.faceEmpty
   var color = R.Color.veryLightPinkFour
 }

--- a/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
@@ -6,3 +6,43 @@
 //
 
 import Foundation
+
+
+// MARK: - EventDTO
+struct EventDTO: Decodable {
+  let id: String
+  let eventName: String
+  let eventIcon:String
+  let date: String
+  let participant: [Participant]
+  
+  enum CodingKeys: String, CodingKey {
+    case id = "_id"
+    case eventName, eventIcon, date, participant
+  }
+}
+
+// MARK: - Participant
+struct Participant: Decodable {
+  let id: String
+  let userName: String
+  let typeIcon: String
+  
+  enum CodingKeys: String, CodingKey {
+    case id = "_id"
+    case userName, typeIcon
+  }
+}
+
+extension EventDTO {
+  static let sampleData: EventDTO = EventDTO(
+    id: "62c940dfa940516bebb8c668",
+    eventName: "혜정이 생파",
+    eventIcon: "BEER",
+    date: "2023-11-15",
+    participant: [
+      Participant(id: "62c871289bfca489f95f6a0a", userName: "고구마", typeIcon: "GRAY"),
+      Participant(id: "62c8712b9bfca489f95f6a0d", userName: "감자", typeIcon: "RED")
+    ]
+  )
+}

--- a/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
@@ -1,0 +1,8 @@
+//
+//  EventDTO.swift
+//  Hous-iOS
+//
+//  Created by 김민재 on 2022/07/15.
+//
+
+import Foundation

--- a/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/Home/EventDTO.swift
@@ -41,8 +41,7 @@ extension EventDTO {
     eventIcon: "BEER",
     date: "2023-11-15",
     participant: [
-      Participant(id: "62c871289bfca489f95f6a0a", userName: "고구마", typeIcon: "GRAY"),
-      Participant(id: "62c8712b9bfca489f95f6a0d", userName: "감자", typeIcon: "RED")
+      Participant(id: "62cc7420d7868591384e4eb0", userName: "고구마", typeIcon: "GRAY")
     ]
   )
 }

--- a/Hous-iOS/Hous-iOS/Network/Model/Home/HomeDTO.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/Home/HomeDTO.swift
@@ -59,7 +59,8 @@ extension HomeDTO {
       TodoList(
         isCheck: true, todoName: "개발하기", createdAt: "2022-07-11T20:00:10.985Z")],
     homieProfileList: [
-      HomieProfileList(id: "62cc7420d7868591384e4eb0", userName: "고구마", typeName: "임시 디폴트", typeColor: "GRAY")
+      HomieProfileList(id: "62cc7420d7868591384e4eb0", userName: "고구마", typeName: "임시 디폴트", typeColor: "GRAY"),
+      HomieProfileList(id: "62cc7420d7868512384e4eb9", userName: "김민재", typeName: "임시 디폴트", typeColor: "RED")
     ],
     roomCode: "JEVY4Q2G"
   )

--- a/Hous-iOS/Hous-iOS/Network/Model/Home/HomeDTO.swift
+++ b/Hous-iOS/Hous-iOS/Network/Model/Home/HomeDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - DataClass
+// MARK: - HomeDTO
 struct HomeDTO: Decodable {
   let eventList: [EventList]
   let keyRulesList: [String]

--- a/Hous-iOS/Hous-iOS/Screens/Home/Cell/Event/ComingEventsCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/Cell/Event/ComingEventsCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ComingEventsCollectionViewCellDelegate: AnyObject {
-  func showPopup(_ data: EventDTO)
+  func showPopup(_ data: EventDTO?, row: Int)
 }
 
 
@@ -85,13 +85,18 @@ class ComingEventsCollectionViewCell: UICollectionViewCell {
 extension ComingEventsCollectionViewCell: UICollectionViewDelegate {
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    if indexPath.row == 0 {
+      delegate?.showPopup(nil, row: indexPath.row)
+      return
+    }
+    
     guard let data = homeData else { return }
     let eventId = data.eventList[indexPath.row - 1].id
     
     getEventInfo(id: eventId)
     
     guard let eventData = eventData else { return }
-    delegate?.showPopup(eventData)
+    delegate?.showPopup(eventData, row: indexPath.row)
   }
 }
 

--- a/Hous-iOS/Hous-iOS/Screens/Home/Cell/Event/ComingEventsCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/Cell/Event/ComingEventsCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ComingEventsCollectionViewCellDelegate: AnyObject {
-  func showPopup(_ icon: UIImage)
+  func showPopup(_ data: EventDTO)
 }
 
 
@@ -22,7 +22,10 @@ class ComingEventsCollectionViewCell: UICollectionViewCell {
   
   weak var delegate: ComingEventsCollectionViewCellDelegate?
   
+  //MARK: Network
+  
   var homeData: HomeDTO?
+  var eventData: EventDTO?
   
   private var incomingEventsCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout()).then {
     let layout = UICollectionViewFlowLayout()
@@ -71,20 +74,25 @@ class ComingEventsCollectionViewCell: UICollectionViewCell {
     cell.background3DIconImageView.isHidden = false
     cell.background3DIconImageView.alpha = 0.6
   }
+  
+  private func getEventInfo(id: String) {
+    // Request 후
+    eventData = EventDTO.sampleData
+  }
 }
 
 
 extension ComingEventsCollectionViewCell: UICollectionViewDelegate {
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    if indexPath.row == 0 {
-      delegate?.showPopup(R.Image.partyYellowSmall)
-      return
-    }
-    guard let eventIcon = EventDataModel.sampleData[indexPath.row - 1].eventImage else { return }
-    delegate?.showPopup(eventIcon)
+    guard let data = homeData else { return }
+    let eventId = data.eventList[indexPath.row - 1].id
+    
+    getEventInfo(id: eventId)
+    
+    guard let eventData = eventData else { return }
+    delegate?.showPopup(eventData)
   }
-  
 }
 
 extension ComingEventsCollectionViewCell: UICollectionViewDataSource {

--- a/Hous-iOS/Hous-iOS/Screens/Home/Cell/PopUp/ParticipantsCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/Cell/PopUp/ParticipantsCollectionViewCell.swift
@@ -51,9 +51,19 @@ class ParticipantsCollectionViewCell: UICollectionViewCell {
     }
   }
   
-  func setParticipantData(_ data: ParticipantsDataModel) {
-    participantButton.setBackgroundImage(data.participantImage, for: .normal)
-    participantButton.setBackgroundImage(R.Image.faceCheckedRed, for: .selected)
-    participantNameLabel.text = data.participantName
+  func setParticipantData(_ data: HomieProfileList, isSelected flag: Bool?) {
+    let factory = AssigneeFactory.makeAssignee(type: AssigneeColor(rawValue: data.typeColor.lowercased()) ?? .none)
+    
+    participantButton.setBackgroundImage(factory.faceImage, for: .normal)
+    participantButton.setBackgroundImage(factory.checkedFaceImage, for: .selected)
+    
+    if let flag = flag {
+      participantButton.isSelected = flag
+    } else {
+      participantButton.isSelected = false
+    }
+    
+    
+    participantNameLabel.text = data.userName
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Home/Cell/Profile/ProfileCollectionViewCell.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/Cell/Profile/ProfileCollectionViewCell.swift
@@ -81,7 +81,7 @@ class ProfileCollectionViewCell: UICollectionViewCell {
   func setProfileData(_ data: HomieProfileList) {
     profileNameLabel.text = data.userName
     
-    let factory = AssigneeFactory.makeAssignee(type: AssigneeColor(rawValue: data.userName.lowercased()) ?? .none)
+    let factory = AssigneeFactory.makeAssignee(type: AssigneeColor(rawValue: data.typeColor.lowercased()) ?? .none)
     profileImage.image = factory.faceImage
     self.backgroundColor = factory.color.withAlphaComponent(0.5)
   }

--- a/Hous-iOS/Hous-iOS/Screens/Home/View/EventDateView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/View/EventDateView.swift
@@ -139,32 +139,32 @@ class EventDateView: UIView {
     
   }
   
-  
-  
+  func setDateLabel(date: String) {
+    guard let date = date.toDate() else { return }
+    
+    let year = date.year
+    let month = date.month
+    let day = date.day
+    
+    let attributes = [
+      NSAttributedString.Key.foregroundColor : UIColor.black,
+      .font : UIFont.font(.montserratMedium, ofSize: 15)
+    ]
+
+    yearDatePickerTextField.attributedPlaceholder = NSAttributedString(string: year.description, attributes: attributes)
+    monthDatePickerTextField.attributedPlaceholder = NSAttributedString(string: month.description, attributes: attributes)
+    dayDatePickerTextField.attributedPlaceholder = NSAttributedString(string: day.description, attributes: attributes)
+  }
 }
 
 //MARK: Objective-C methods
 extension EventDateView {
   @objc private func handleDatePickerData() {
     let dateformatter = DateFormatter()
-    dateformatter.dateStyle = .long
-    dateformatter.timeStyle = .none
+    dateformatter.dateFormat = "yyyy-MM-dd"
     let date = dateformatter.string(from: datePicker.date)
     
-    let year = date[date.startIndex..<date.index(date.startIndex, offsetBy: 4)]
-    
-    let month = date[date.index(date.startIndex, offsetBy: 6) ..< date.index(date.startIndex, offsetBy: 8)].description.replacingOccurrences(of: "월", with: "")
-    
-    let day = date[date.index(date.endIndex, offsetBy: -3) ..< date.index(before: date.endIndex)]
-    
-    let attributes = [
-      NSAttributedString.Key.foregroundColor : UIColor.black,
-      .font : UIFont.font(.montserratMedium, ofSize: 15)
-    ]
-    
-    yearDatePickerTextField.attributedPlaceholder = NSAttributedString(string: year.description, attributes: attributes)
-    monthDatePickerTextField.attributedPlaceholder = NSAttributedString(string: month.description, attributes: attributes)
-    dayDatePickerTextField.attributedPlaceholder = NSAttributedString(string: day.description, attributes: attributes)
+    setDateLabel(date: date)
   }
   
   @objc private func dismissDatePicker() {

--- a/Hous-iOS/Hous-iOS/Screens/Home/View/EventDateView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/View/EventDateView.swift
@@ -22,7 +22,7 @@ class EventDateView: UIView {
   private let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: nil, action: #selector(dismissDatePicker))
   
   private lazy var toolBar = UIToolbar().then {
-    $0.setItems([flexibleButton, cancelButton, flexibleButton, doneButton, flexibleButton], animated: false)
+    $0.setItems([cancelButton, flexibleButton, doneButton], animated: false)
     $0.sizeToFit()
   }
   
@@ -50,6 +50,7 @@ class EventDateView: UIView {
   }
   
   private lazy var monthDatePickerTextField = UITextField().then {
+    $0.inputAccessoryView = toolBar
     $0.tintColor = .clear
     $0.inputView = datePicker
     $0.textAlignment = .center
@@ -68,6 +69,7 @@ class EventDateView: UIView {
   }
   
   private lazy var dayDatePickerTextField = UITextField().then {
+    $0.inputAccessoryView = toolBar
     $0.tintColor = .clear
     $0.inputView = datePicker
     $0.textAlignment = .center

--- a/Hous-iOS/Hous-iOS/Screens/Home/View/EventIconView.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/View/EventIconView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class EventIconView: UIView {
   
+  var eventCase: IconImage = .party
+  
   let iconImageView = UIImageView().then {
     $0.isUserInteractionEnabled = true
     $0.backgroundColor = .offWhite

--- a/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
@@ -244,15 +244,26 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
 
 extension HomeViewController: ComingEventsCollectionViewCellDelegate {
   
-  func showPopup(_ data: EventDTO) {
+  func showPopup(_ data: EventDTO?, row: Int) {
     let popUp = PopUpViewController()
     popUp.modalTransitionStyle = .crossDissolve
     popUp.modalPresentationStyle = .overFullScreen
     
-    popUp.setPopUpData(data)
-    
-    popUp.selectedEventCase = IconImage(rawValue: data.eventIcon.lowercased())!
     popUp.homeData = self.homeData
+    
+    if row == 0 {
+      popUp.setDefaultPopUpData(R.Image.partyYellowSmall)
+      popUp.isDefaultPopUp = true
+      present(popUp, animated: true)
+      return
+    }
+    
+    popUp.isDefaultPopUp = false
+    guard let eventData = data else { return }
+    
+    popUp.setPopUpData(eventData)
+    popUp.selectedEventCase = IconImage(rawValue: eventData.eventIcon.lowercased())!
+    
     present(popUp, animated: true)
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
@@ -252,6 +252,7 @@ extension HomeViewController: ComingEventsCollectionViewCellDelegate {
     popUp.setPopUpData(data)
     
     popUp.selectedEventCase = IconImage(rawValue: data.eventIcon.lowercased())!
+    popUp.homeData = self.homeData
     present(popUp, animated: true)
   }
 }

--- a/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/ViewController/HomeViewController.swift
@@ -244,13 +244,14 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
 
 extension HomeViewController: ComingEventsCollectionViewCellDelegate {
   
-  func showPopup(_ icon: UIImage) {
+  func showPopup(_ data: EventDTO) {
     let popUp = PopUpViewController()
     popUp.modalTransitionStyle = .crossDissolve
     popUp.modalPresentationStyle = .overFullScreen
-    popUp.eventImageView.image = icon
+    
+    popUp.setPopUpData(data)
+    
+    popUp.selectedEventCase = IconImage(rawValue: data.eventIcon.lowercased())!
     present(popUp, animated: true)
   }
 }
-
-

--- a/Hous-iOS/Hous-iOS/Screens/Home/ViewController/PopUpViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/ViewController/PopUpViewController.swift
@@ -22,6 +22,8 @@ class PopUpViewController: UIViewController {
     }
   }
   
+  var isDefaultPopUp: Bool = false
+  
   private enum Size {
     static let screenWidth = UIScreen.main.bounds.width
     static let eventIconSize = CGSize(width: 44, height: 68)
@@ -294,6 +296,10 @@ class PopUpViewController: UIViewController {
     eventDateView.setDateLabel(date: date)
   }
   
+  func setDefaultPopUpData(_ icon: UIImage) {
+    eventImageView.image = icon
+  }
+  
   private func getEventInfo() {
     eventData = EventDTO.sampleData
   }
@@ -366,8 +372,13 @@ extension PopUpViewController: UICollectionViewDataSource {
       
       let isSelected = isSelectedArray[indexPath.row]
       
-      cell.setParticipantData(homeData.homieProfileList[indexPath.row], isSelected: isSelected)
       
+      if isDefaultPopUp {
+        cell.setParticipantData(homeData.homieProfileList[indexPath.row], isSelected: nil)
+        return cell
+      }
+      
+      cell.setParticipantData(homeData.homieProfileList[indexPath.row], isSelected: isSelected)
       return cell
     }
 

--- a/Hous-iOS/Hous-iOS/Screens/Home/ViewController/PopUpViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Home/ViewController/PopUpViewController.swift
@@ -11,6 +11,17 @@ import Then
 
 class PopUpViewController: UIViewController {
   
+  var selectedEventCase: IconImage = .party {
+    didSet {
+      iconStackView.subviews.forEach {
+        guard let iconView = $0 as? EventIconView else { return }
+        if selectedEventCase == iconView.eventCase {
+          self.setTouchedIcon(iconView)
+        }
+      }
+    }
+  }
+  
   private enum Size {
     static let screenWidth = UIScreen.main.bounds.width
     static let eventIconSize = CGSize(width: 44, height: 68)
@@ -19,21 +30,25 @@ class PopUpViewController: UIViewController {
   private let maxEventLength = 10
   
   private let partyIconImageView = EventIconView().then {
+    $0.eventCase = .party
     $0.tag = 0
     $0.iconImageView.image = R.Image.partyYellowSmall
   }
   
   private let cakeIconImageView = EventIconView().then {
+    $0.eventCase = .cake
     $0.tag = 1
     $0.iconImageView.image = R.Image.cakeYellowSmall
   }
   
   private let beerIconImageView = EventIconView().then {
+    $0.eventCase = .beer
     $0.tag = 2
     $0.iconImageView.image = R.Image.beerYellowSmall
   }
   
   private let coffeeIconImageView = EventIconView().then {
+    $0.eventCase = .coffee
     $0.tag = 3
     $0.iconImageView.image = R.Image.coffeeYellowSmall
   }
@@ -62,7 +77,7 @@ class PopUpViewController: UIViewController {
     $0.tintColor = .housBlack
   }
   
-  var eventImageView = UIImageView().then {
+  private var eventImageView = UIImageView().then {
     $0.contentMode = .scaleAspectFit
     $0.backgroundColor = R.Color.offWhite
     $0.image = R.Image.partyYellow
@@ -243,6 +258,18 @@ class PopUpViewController: UIViewController {
     participantsCollectionView.delegate = self
     participantsCollectionView.dataSource = self
   }
+  
+  func setPopUpData(_ data: EventDTO) {
+    let iconFactory = IconFactory.makeIcon(type: IconImage(rawValue: data.eventIcon.lowercased()) ?? .party)
+    
+    eventImageView.image = iconFactory.smallIconImage
+    eventTextField.text = data.eventName
+    
+    
+    let date = data.date
+    
+    eventDateView.setDateLabel(date: date)
+  }
 }
 
 
@@ -271,15 +298,19 @@ extension PopUpViewController {
       guard let eventIconView = $0 as? EventIconView else { return }
       
       if eventIconView == view.viewWithTag(view.tag) {
-        eventIconView.iconImageView.backgroundColor = .paleGold
-        eventIconView.iconImageView.alpha = 0.4
-        eventIconView.iconForegroundImageView.isHidden = false
-        eventImageView.image = eventIconView.iconImageView.image
+        setTouchedIcon(eventIconView)
       } else {
         eventIconView.iconImageView.backgroundColor = .offWhite
         eventIconView.iconForegroundImageView.isHidden = true
       }
     }
+  }
+  
+  func setTouchedIcon(_ iconView: EventIconView) {
+    iconView.iconImageView.backgroundColor = .paleGold
+    iconView.iconImageView.alpha = 0.4
+    iconView.iconForegroundImageView.isHidden = false
+    eventImageView.image = iconView.iconImageView.image
   }
 }
 

--- a/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
+++ b/Hous-iOS/Hous-iOS/Screens/Rules/PopUp/RulesAssignPopUpViewController.swift
@@ -125,7 +125,7 @@ extension TodayTodoAssignPopUpViewController: UICollectionViewDataSource {
       guard let cell = assigneeCollectionView.dequeueReusableCell(withReuseIdentifier: ParticipantsCollectionViewCell.className, for: indexPath) as? ParticipantsCollectionViewCell else { return UICollectionViewCell() }
 
       cell.contentView.isUserInteractionEnabled = true
-      cell.setParticipantData(ParticipantsDataModel.sampleData[indexPath.row])
+      cell.setParticipantData(HomeDTO.sampleData.homieProfileList[indexPath.row], isSelected: nil)
 
       return cell
     }


### PR DESCRIPTION
## 🌱 작업한 내용

- datepicker calendar를 이용해서 year, month, day textField에 넣어주기
- 팝업창 화면전환시에 이벤트 아이콘, 참여자 선택된 채로 넘어가기

## 🌱 PR Point

- 화면전환시 선택되어 있는 상태로 보여주는게 좀 까다롭네요..
- 이벤트 아이콘은 지현이가 도와줘서 좀 깔끔한데 참여자 부분이 좀 많이 더러운 것 같은 느낌ㅜ

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 팝업창 화면 | ![Simulator Screen Recording - iPhone 13 mini - 2022-07-16 at 19 45 31](https://user-images.githubusercontent.com/60292150/179351742-2044bd81-fb0a-4939-a2a5-ec3a87b06c94.gif) |



## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- closed: #40 
